### PR TITLE
add support for kitty

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./bat.nix
     ./bottom.nix
+    ./kitty.nix
     ./starship.nix
     ./helix.nix
     ./gtk.nix

--- a/modules/home-manager/kitty.nix
+++ b/modules/home-manager/kitty.nix
@@ -1,0 +1,23 @@
+{ config, lib, ... }:
+let cfg = config.programs.kitty.catppuccin;
+in {
+  options.programs.kitty.catppuccin = with lib; {
+    enable = mkEnableOption "Catppuccin theme";
+    flavour = mkOption {
+      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
+      default = config.catppuccin.flavour;
+      description = "Catppuccin flavour for kitty";
+    };
+  };
+
+  config.programs.kitty = with lib;
+    let
+      # string -> string
+      # this capitalizes the first letter in a string
+      # it's used to set the theme name correctly here
+      mkUpper = word:
+        (toUpper (substring 0 1 word)) + (substring 1 (stringLength word) word);
+
+      flavourUpper = mkUpper cfg.flavour;
+    in mkIf cfg.enable { theme = "Catppuccin-${flavourUpper}"; };
+}


### PR DESCRIPTION
this adds support for the [kitty](https://github.com/catppuccin/kitty) theme

i was also thinking of maybe making a utils file like my previous prs, but with general functions others might need to use (like with `mkUpper` in this case since it's also used by the gtk hm module). let me know what you think :)