### PR TITLE
add util library

### DIFF
--- a/modules/home-manager/alacritty.nix
+++ b/modules/home-manager/alacritty.nix
@@ -1,14 +1,8 @@
 { config, pkgs, lib, ... }:
 let cfg = config.programs.alacritty.catppuccin;
 in {
-  options.programs.alacritty.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for alacritty";
-    };
-  };
+  options.programs.alacritty.catppuccin =
+    lib.ctp.mkCatppuccinOpt "alacritty" config;
 
   config.programs.alacritty.settings = with builtins;
     with lib;

--- a/modules/home-manager/bat.nix
+++ b/modules/home-manager/bat.nix
@@ -1,14 +1,8 @@
 { config, pkgs, lib, ... }:
 let cfg = config.programs.bat.catppuccin; in
 {
-  options.programs.bat.catppuccin = {
-    enable = lib.mkEnableOption "Catppuccin theme";
-    flavour = lib.mkOption {
-      type = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for bat";
-    };
-  };
+  options.programs.bat.catppuccin =
+    lib.ctp.mkCatppuccinOpt "bat" config;
 
   config = {
     home.activation.batCache = "${pkgs.bat}/bin/bat cache --build";

--- a/modules/home-manager/bottom.nix
+++ b/modules/home-manager/bottom.nix
@@ -1,14 +1,8 @@
 { config, pkgs, lib, ... }:
 let cfg = config.programs.bottom.catppuccin;
 in {
-  options.programs.bottom.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for bottom";
-    };
-  };
+  options.programs.bottom.catppuccin =
+    lib.ctp.mkCatppuccinOpt "bottom" config;
 
   config.programs.bottom.settings = with builtins;
     with lib;

--- a/modules/home-manager/btop.nix
+++ b/modules/home-manager/btop.nix
@@ -9,14 +9,8 @@ let
     sha256 = "sha256-QoPPx4AzxJMYo/prqmWD/CM7e5vn/ueyx+XQ5+YfHF8=";
   } + themePath;
 in {
-  options.programs.btop.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for btop";
-    };
-  };
+  options.programs.btop.catppuccin =
+    lib.ctp.mkCatppuccinOpt "btop" config;
 
   # xdg is required for this to work
   config.xdg.enable = with lib; mkIf cfg.enable (mkForce true);

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,16 +1,21 @@
-{ config, pkgs, lib, ... }: {
-  imports = [
-    ./alacritty.nix
-    ./bat.nix
-    ./bottom.nix
-    ./btop.nix
-    ./kitty.nix
-    ./starship.nix
-    ./helix.nix
-    ./gtk.nix
-    ./polybar.nix
-    ./tmux.nix
-  ];
+{ config, pkgs, lib, ... }: let
+ extendedLib = import ../lib/mkExtLib.nix lib;
+in {
+  imports = let
+    files = [
+      ./alacritty.nix
+      ./bat.nix
+      ./bottom.nix
+      ./btop.nix
+      ./kitty.nix
+      ./starship.nix
+      ./helix.nix
+      ./gtk.nix
+      ./polybar.nix
+      ./tmux.nix
+    ];
+  in extendedLib.ctp.mapModules config pkgs extendedLib files;
+
   options.catppuccin = {
     flavour = lib.mkOption {
       type = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -1,18 +1,10 @@
 { config, pkgs, lib, ... }:
 let cfg = config.gtk.catppuccin;
 in {
-  options.gtk.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for gtk";
-    };
-    accent = mkOption {
-      type = types.enum [ "blue" "flamingo" "green" "lavender" "maroon" "mauve" "peach" "pink" "red" "rosewater" "sapphire" "sky" "teal" "yellow" ];
-      default = config.catppuccin.accent;
-      description = "Catppuccin accents for gtk";
-    };
+  options.gtk.catppuccin =
+    lib.ctp.mkCatppuccinOpt "gtk" config // (
+    with lib; {
+    accent = ctp.mkAccentOpt "gtk" config;
     size = mkOption {
       type = types.enum [ "standard" "compact" ];
       default = "standard";
@@ -23,19 +15,14 @@ in {
       default = [ "normal" ];
       description = "Catppuccin tweaks for gtk";
     };
-  };
+  });
 
-  config.gtk.theme = with lib;
-    with builtins;
+  config.gtk.theme = with builtins;
+    with lib;
     let
-      # string -> string
-      # this capitalizes the first letter in a string
-      # it's used to set the theme name correctly here
-      mkUpper = word: (toUpper (substring 0 1 word)) + (substring 1 (stringLength word) word);
-
-      flavourUpper = mkUpper cfg.flavour;
-      accentUpper = mkUpper cfg.accent;
-      sizeUpper = mkUpper cfg.size;
+      flavourUpper = ctp.mkUpper cfg.flavour;
+      accentUpper = ctp.mkUpper cfg.accent;
+      sizeUpper = ctp.mkUpper cfg.size;
 
       # use the light gtk theme for latte
       gtkTheme = if cfg.flavour == "latte" then "Light" else "Dark";

--- a/modules/home-manager/helix.nix
+++ b/modules/home-manager/helix.nix
@@ -1,15 +1,10 @@
 { config, pkgs, lib, ... }:
 let cfg = config.programs.helix.catppuccin;
 in {
-  options.programs.helix.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for Helix";
+  options.programs.helix.catppuccin =
+    lib.ctp.mkCatppuccinOpt "helix" config // {
+      useItalics = lib.mkEnableOption "Italics in Catppuccin theme for Helix";
     };
-    useItalics = mkEnableOption "Italics in Catppuccin theme for Helix";
-  };
 
   config.programs.helix = with builtins;
     with lib;

--- a/modules/home-manager/kitty.nix
+++ b/modules/home-manager/kitty.nix
@@ -1,23 +1,11 @@
 { config, lib, ... }:
 let cfg = config.programs.kitty.catppuccin;
 in {
-  options.programs.kitty.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for kitty";
-    };
-  };
+  options.programs.kitty.catppuccin =
+    lib.ctp.mkCatppuccinOpt "kitty" config;
 
   config.programs.kitty = with lib;
-    let
-      # string -> string
-      # this capitalizes the first letter in a string
-      # it's used to set the theme name correctly here
-      mkUpper = word:
-        (toUpper (substring 0 1 word)) + (substring 1 (stringLength word) word);
-
-      flavourUpper = mkUpper cfg.flavour;
+    with ctp;
+    let flavourUpper = mkUpper cfg.flavour;
     in mkIf cfg.enable { theme = "Catppuccin-${flavourUpper}"; };
 }

--- a/modules/home-manager/polybar.nix
+++ b/modules/home-manager/polybar.nix
@@ -1,14 +1,8 @@
 { config, pkgs, lib, ... }:
 let cfg = config.services.polybar.catppuccin;
 in {
-  options.services.polybar.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for polybar";
-    };
-  };
+  options.services.polybar.catppuccin =
+    lib.ctp.mkCatppuccinOpt "polybar" config;
 
   config.services.polybar.extraConfig = with builtins;
     with lib;

--- a/modules/home-manager/starship.nix
+++ b/modules/home-manager/starship.nix
@@ -1,14 +1,8 @@
 { config, pkgs, lib, ... }:
 let cfg = config.programs.starship.catppuccin; in
 {
-  options.programs.starship.catppuccin = {
-    enable = lib.mkEnableOption "Catppuccin theme";
-    flavour = lib.mkOption {
-      type = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for starship";
-    };
-  };
+  options.programs.starship.catppuccin =
+    lib.ctp.mkCatppuccinOpt "starship" config;
 
   config.programs.starship.settings = lib.mkIf cfg.enable
     ({

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -16,14 +16,8 @@ let
       };
     };
 in {
-  options.programs.tmux.catppuccin = with lib; {
-    enable = mkEnableOption "Catppuccin theme";
-    flavour = mkOption {
-      type = types.enum [ "latte" "frappe" "macchiato" "mocha" ];
-      default = config.catppuccin.flavour;
-      description = "Catppuccin flavour for tmux";
-    };
-  };
+  options.programs.tmux.catppuccin =
+    lib.ctp.mkCatppuccinOpt "tmux" config;
 
   config.programs.tmux.plugins = with lib; mkIf cfg.enable [
     {

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -1,0 +1,75 @@
+lib:
+with builtins;
+with lib; rec {
+  # string -> string
+  # this capitalizes the first letter in a string,
+  # which is sometimes needed in order to format
+  # the names of themes correctly
+  mkUpper = word:
+    (toUpper (substring 0 1 word)) + (substring 1 (stringLength word) word);
+
+  # a -> a -> [path] -> [path]
+  # this imports a list of paths while inheriting
+  # multiple attributes
+  mapModules = config: pkgs: extendedLib:
+    map (m:
+      (import m {
+        inherit config pkgs;
+        lib = extendedLib;
+      }));
+
+  types = {
+    flavourOption = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];
+    accentOption = lib.types.enum [
+      "blue"
+      "flamingo"
+      "green"
+      "lavender"
+      "maroon"
+      "mauve"
+      "peach"
+      "pink"
+      "red"
+      "rosewater"
+      "sapphire"
+      "sky"
+      "teal"
+      "yellow"
+    ];
+  };
+
+  # string -> type -> string -> a -> a
+  # this is an internal function and shouldn't be
+  # used unless you know what you're doing. it takes
+  # a string (the name of the property, i.e., flavour
+  # or accent), the type of the property, the name of
+  # the module, followed by local config attrset
+  mkBasicOpt = attr: type: name: config:
+    mkOption {
+      inherit type;
+      default = config.catppuccin.${attr};
+      description = "Catppuccin ${attr} for ${name}";
+    };
+
+  # string -> a -> a
+  # this creates a flavour option for modules
+  # the first string should be the name of the module,
+  # followed by the local config attrset
+  mkFlavourOpt = mkBasicOpt "flavour" types.flavourOption;
+
+  # string -> a -> a
+  # this creates an accent option for modules
+  # the first string should be the name of the module,
+  # followed by the local config attrset
+  mkAccentOpt = mkBasicOpt "accent" types.accentOption;
+
+  # string -> a -> a
+  # this creates a basic attrset only containing an
+  # enable and flavour option. the fist string should
+  # be the name of the module, followed by the local config
+  # attrset
+  mkCatppuccinOpt = name: config: {
+    enable = mkEnableOption "Catppuccin theme";
+    flavour = mkFlavourOpt name config;
+  };
+}

--- a/modules/lib/mkExtLib.nix
+++ b/modules/lib/mkExtLib.nix
@@ -1,0 +1,1 @@
+lib: with builtins; lib.extend (self: _: { ctp = import ./. self; })

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,4 +1,13 @@
-{ lib, ... }: {
+{ config, pkgs, lib, ... }: let
+ extendedLib = import ../lib/mkExtLib.nix lib;
+in {
+  imports = let
+    files = [
+    ];
+  in
+    extendedLib.ctp.mapModules config pkgs extendedLib files;
+
+
   options.catppuccin = {
     flavour = lib.mkOption {
       type = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];


### PR DESCRIPTION
this adds (or opens up) a few helper expressions to the project:

- `mkUpper`

  - capitalizes the first letter of a string (sometimes needed for formatting)

- `mapModules`

  - this is used in order to share the extended library globally

- `types`

  - this is an attrset containing enums of flavours and accents, so we don't have to type so much anymore

- `mkBasicOpt`

  - this is mainly an internal function to generate options without too much boilerplate

- `mkFlavourOpt`

  - this creates a flavour option based on the psuedo-template we've been using

- `mkAccentOpt`

  - ditto, but with accents

- `mkCatppuccinOpt`
  - this is probably the most helpful since it basically removes the need to declare options for modules that only use `flavour` (the majority)
  
overall, i think these can all make contributing faster and easier, especially for regulars who become familiar with this library -- and unlike my previous pr, it won't change the workflow of those who prefer to just use standard declarations since it doesn't force any "magic." the only major complication this adds is the map at the end of `imports` arrays, but i think that's an okay tradeoff here given the benefits of these expressions