### PR TITLE
vendor nixpkgs, cleanup some stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v20
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}        
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run formatter
-        run: nix run nixpkgs#nixpkgs-fmt .
+        run: nix fmt
       - name: Check for changes
         run: git diff --color=always --exit-code

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,25 @@
         "type": "github"
       }
     },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685655444,
+        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat"
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,27 @@
     };
   };
 
-  outputs = { nixpkgs, ... }: {
-    nixosModules.catppuccin = import ./modules/nixos nixpkgs;
-    homeManagerModules.catppuccin = import ./modules/home-manager nixpkgs;
-  };
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+      forEachSystem = fn:
+        forAllSystems (system:
+          fn {
+            inherit system;
+            pkgs = nixpkgsFor.${system};
+          });
+    in
+    {
+      nixosModules.catppuccin = import ./modules/nixos nixpkgs;
+      homeManagerModules.catppuccin = import ./modules/home-manager nixpkgs;
+      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixpkgs-fmt);
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,15 @@
 {
   description = "Soothing pastel theme for Nix";
   inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
   };
 
-  outputs = _: {
-    nixosModules.catppuccin = import ./modules/nixos;
-    homeManagerModules.catppuccin = import ./modules/home-manager;
+  outputs = { nixpkgs, ... }: {
+    nixosModules.catppuccin = import ./modules/nixos nixpkgs;
+    homeManagerModules.catppuccin = import ./modules/home-manager nixpkgs;
   };
 }

--- a/modules/home-manager/bat.nix
+++ b/modules/home-manager/bat.nix
@@ -5,8 +5,6 @@ let cfg = config.programs.bat.catppuccin; in
     lib.ctp.mkCatppuccinOpt "bat" config;
 
   config = {
-    home.activation.batCache = "${pkgs.bat}/bin/bat cache --build";
-
     programs.bat = lib.mkIf cfg.enable {
       config.theme = "Catppuccin-${cfg.flavour}";
       themes."Catppuccin-${cfg.flavour}" = builtins.readFile (pkgs.fetchFromGitHub

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,6 +1,6 @@
-{ config, pkgs, lib, ... }:
+nixpkgs: { config, pkgs, lib, ... }:
 let
-  extendedLib = import ../lib/mkExtLib.nix lib;
+  extendedLib = import ../lib/mkExtLib.nix nixpkgs.lib;
 in
 {
   imports =

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,6 +1,6 @@
-{ config, pkgs, lib, ... }:
+nixpkgs: { config, pkgs, lib, ... }:
 let
-  extendedLib = import ../lib/mkExtLib.nix lib;
+  extendedLib = import ../lib/mkExtLib.nix nixpkgs.lib;
 in
 {
   imports =


### PR DESCRIPTION
as the title says, this vendors nixpkgs, fixing possible issues for those using outdated revisions. with this change, the formatter can also now be set in a flake attribute and `nix fmt` can be used.

i also fixed a bug in the module for bat, which blocked hm activation packages from building due to the command we set now being a default :)