### PR TITLE
chore(home-manager): adopt new naming scheme for gtk theme

### DIFF
--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -24,7 +24,7 @@ in {
       sizeUpper = ctp.mkUpper cfg.size;
 
       # use the light gtk theme for latte
-      gtkTheme = if cfg.flavour == "latte" then "Light" else "Dark";
+      gtkTheme = if cfg.flavour == "latte" then "light" else "dark";
 
     in
     mkIf cfg.enable {


### PR DESCRIPTION
the dark/light suffix is now lowercase as of https://github.com/catppuccin/gtk/releases/tag/v0.6.1