### PR TITLE
fix(home-manager): dont declare xdg.configFile when btop isn't enabled

### DIFF
--- a/modules/home-manager/btop.nix
+++ b/modules/home-manager/btop.nix
@@ -1,25 +1,34 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.programs.btop.catppuccin;
   themePath = "/themes/catppuccin_${cfg.flavour}.theme";
-  theme = pkgs.fetchFromGitHub
-    {
-      owner = "catppuccin";
-      repo = "btop";
-      rev = "7109eac2884e9ca1dae431c0d7b8bc2a7ce54e54";
-      sha256 = "sha256-QoPPx4AzxJMYo/prqmWD/CM7e5vn/ueyx+XQ5+YfHF8=";
-    } + themePath;
+  theme =
+    pkgs.fetchFromGitHub
+      {
+        owner = "catppuccin";
+        repo = "btop";
+        rev = "7109eac2884e9ca1dae431c0d7b8bc2a7ce54e54";
+        sha256 = "sha256-QoPPx4AzxJMYo/prqmWD/CM7e5vn/ueyx+XQ5+YfHF8=";
+      }
+    + themePath;
 in
 {
   options.programs.btop.catppuccin =
     lib.ctp.mkCatppuccinOpt "btop" config;
 
   # xdg is required for this to work
-  config.xdg.enable = with lib; mkIf cfg.enable (mkForce true);
+  config =
+    {
+      xdg.enable = with lib; mkIf cfg.enable (mkForce true);
 
-  config.xdg.configFile."btop${themePath}".source = with lib;
-    mkIf cfg.enable theme;
-
-  config.programs.btop.settings.color_theme = with lib;
-    mkIf cfg.enable "${config.xdg.configHome + "/btop/${themePath}"}";
+      programs.btop.settings.color_theme = with lib;
+        mkIf cfg.enable "${config.xdg.configHome + "/btop/${themePath}"}";
+    }
+    // (lib.mkIf cfg.enable {
+      xdg.configFile."btop${themePath}".source = theme;
+    });
 }


### PR DESCRIPTION
this was discovered by a friend. since `mkIf` will return an empty attrset if the condition is false, it will cause an evaluation error when `xdgConfigFile."<file>".source` is set to `{}`.
