### PR TITLE
refactor: use alternatives to `with` and `rec`

### DIFF
--- a/modules/home-manager/alacritty.nix
+++ b/modules/home-manager/alacritty.nix
@@ -1,21 +1,28 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.alacritty.catppuccin;
-in {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (lib) ctp;
+  cfg = config.programs.alacritty.catppuccin;
+  enable = cfg.enable && config.programs.alacritty.enable;
+in
+{
   options.programs.alacritty.catppuccin =
-    lib.ctp.mkCatppuccinOpt "alacritty" config;
+    ctp.mkCatppuccinOpt "alacritty" config;
 
-  config.programs.alacritty.settings = with builtins;
-    with lib;
-    with pkgs;
+  config.programs.alacritty.settings =
     let
-      file = fetchFromGitHub
-        {
-          owner = "catppuccin";
-          repo = "alacritty";
-          rev = "3c808cbb4f9c87be43ba5241bc57373c793d2f17";
-          sha256 = "sha256-w9XVtEe7TqzxxGUCDUR9BFkzLZjG8XrplXJ3lX6f+x0=";
-        } + "/catppuccin-${cfg.flavour}.yml";
-
+      file =
+        pkgs.fetchFromGitHub
+          {
+            owner = "catppuccin";
+            repo = "alacritty";
+            rev = "3c808cbb4f9c87be43ba5241bc57373c793d2f17";
+            sha256 = "sha256-w9XVtEe7TqzxxGUCDUR9BFkzLZjG8XrplXJ3lX6f+x0=";
+          }
+        + "/catppuccin-${cfg.flavour}.yml";
     in
-    mkIf cfg.enable (ctp.fromYaml pkgs file);
+    lib.mkIf enable (ctp.fromYaml pkgs file);
 }

--- a/modules/home-manager/bat.nix
+++ b/modules/home-manager/bat.nix
@@ -1,11 +1,18 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.bat.catppuccin; in
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  cfg = config.programs.bat.catppuccin;
+  enable = cfg.enable && config.programs.bat.enable;
+in
 {
   options.programs.bat.catppuccin =
     lib.ctp.mkCatppuccinOpt "bat" config;
 
   config = {
-    programs.bat = lib.mkIf cfg.enable {
+    programs.bat = lib.mkIf enable {
       config.theme = "Catppuccin-${cfg.flavour}";
       themes."Catppuccin-${cfg.flavour}" = builtins.readFile (pkgs.fetchFromGitHub
         {
@@ -13,7 +20,8 @@ let cfg = config.programs.bat.catppuccin; in
           repo = "bat";
           rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
           sha256 = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
-        } + /Catppuccin-${cfg.flavour}.tmTheme);
+        }
+      + "/Catppuccin-${cfg.flavour}.tmTheme");
     };
   };
 }

--- a/modules/home-manager/bottom.nix
+++ b/modules/home-manager/bottom.nix
@@ -1,17 +1,23 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.bottom.catppuccin;
-in {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (builtins) fromTOML readFile;
+  cfg = config.programs.bottom.catppuccin;
+  enable = cfg.enable && config.programs.bottom.enable;
+in
+{
   options.programs.bottom.catppuccin =
     lib.ctp.mkCatppuccinOpt "bottom" config;
 
-  config.programs.bottom.settings = with builtins;
-    with lib;
-    with pkgs;
-    mkIf cfg.enable (fromTOML (readFile (fetchFromGitHub
-      {
-        owner = "catppuccin";
-        repo = "bottom";
-        rev = "c0efe9025f62f618a407999d89b04a231ba99c92";
-        sha256 = "sha256-VaHX2I/Gn82wJWzybpWNqU3dPi3206xItOlt0iF6VVQ=";
-      } + "/themes/${cfg.flavour}.toml")));
+  config.programs.bottom.settings = lib.mkIf enable (fromTOML (readFile (pkgs.fetchFromGitHub
+    {
+      owner = "catppuccin";
+      repo = "bottom";
+      rev = "c0efe9025f62f618a407999d89b04a231ba99c92";
+      sha256 = "sha256-VaHX2I/Gn82wJWzybpWNqU3dPi3206xItOlt0iF6VVQ=";
+    }
+  + "/themes/${cfg.flavour}.toml")));
 }

--- a/modules/home-manager/btop.nix
+++ b/modules/home-manager/btop.nix
@@ -4,7 +4,10 @@
 , ...
 }:
 let
+  inherit (lib) mkIf;
   cfg = config.programs.btop.catppuccin;
+  enable = cfg.enable && config.programs.btop.enable;
+
   themePath = "/themes/catppuccin_${cfg.flavour}.theme";
   theme =
     pkgs.fetchFromGitHub
@@ -23,12 +26,12 @@ in
   # xdg is required for this to work
   config =
     {
-      xdg.enable = with lib; mkIf cfg.enable (mkForce true);
+      xdg.enable = mkIf enable (lib.mkForce true);
 
-      programs.btop.settings.color_theme = with lib;
-        mkIf cfg.enable "${config.xdg.configHome + "/btop/${themePath}"}";
+      programs.btop.settings.color_theme =
+        mkIf enable "${config.xdg.configHome + "/btop/${themePath}"}";
     }
-    // (lib.mkIf cfg.enable {
+    // (lib.mkIf enable {
       xdg.configFile."btop${themePath}".source = theme;
     });
 }

--- a/modules/home-manager/btop.nix
+++ b/modules/home-manager/btop.nix
@@ -1,25 +1,34 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.programs.btop.catppuccin;
   themePath = "/themes/catppuccin_${cfg.flavour}.theme";
-  theme = pkgs.fetchFromGitHub
-    {
-      owner = "catppuccin";
-      repo = "btop";
-      rev = "7109eac2884e9ca1dae431c0d7b8bc2a7ce54e54";
-      sha256 = "sha256-QoPPx4AzxJMYo/prqmWD/CM7e5vn/ueyx+XQ5+YfHF8=";
-    } + themePath;
+  theme =
+    pkgs.fetchFromGitHub
+      {
+        owner = "catppuccin";
+        repo = "btop";
+        rev = "7109eac2884e9ca1dae431c0d7b8bc2a7ce54e54";
+        sha256 = "sha256-QoPPx4AzxJMYo/prqmWD/CM7e5vn/ueyx+XQ5+YfHF8=";
+      }
+    + themePath;
 in
 {
   options.programs.btop.catppuccin =
     lib.ctp.mkCatppuccinOpt "btop" config;
 
   # xdg is required for this to work
-  config.xdg.enable = with lib; mkIf cfg.enable (mkForce true);
+  config =
+    {
+      xdg.enable = with lib; mkIf cfg.enable (mkForce true);
 
-  config.xdg.configFile."btop${themePath}".source = with lib;
-    mkIf cfg.enable theme;
-
-  config.programs.btop.settings.color_theme = with lib;
-    mkIf cfg.enable "${config.xdg.configHome + "/btop/${themePath}"}";
+      programs.btop.settings.color_theme = with lib;
+        mkIf cfg.enable "${config.xdg.configHome + "/btop/${themePath}"}";
+    }
+    // (lib.mkIf cfg.enable {
+      xdg.configFile."btop${themePath}".source = theme;
+    });
 }

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,6 +1,11 @@
-nixpkgs: { config, pkgs, lib, ... }:
+nixpkgs: { config
+         , pkgs
+         , lib
+         , ...
+         }:
 let
   extendedLib = import ../lib/mkExtLib.nix nixpkgs.lib;
+  inherit (extendedLib) ctp;
 in
 {
   imports =
@@ -23,13 +28,13 @@ in
     in
     extendedLib.ctp.mapModules config pkgs extendedLib files;
 
-  options.catppuccin = with extendedLib; {
-    flavour = mkOption {
+  options.catppuccin = {
+    flavour = lib.mkOption {
       type = ctp.types.flavourOption;
       default = "latte";
       description = "Global Catppuccin flavour";
     };
-    accent = mkOption {
+    accent = lib.mkOption {
       type = ctp.types.accentOption;
       default = "teal";
       description = "Global Catppuccin accent";

--- a/modules/home-manager/gtk.nix
+++ b/modules/home-manager/gtk.nix
@@ -1,8 +1,17 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.gtk.catppuccin;
-in {
-  options.gtk.catppuccin = with lib;
-    ctp.mkCatppuccinOpt "gtk" config // {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (lib) ctp mkOption types;
+  cfg = config.gtk.catppuccin;
+  enable = cfg.enable && config.gtk.enable;
+in
+{
+  options.gtk.catppuccin =
+    ctp.mkCatppuccinOpt "gtk" config
+    // {
       accent = ctp.mkAccentOpt "gtk" config;
       size = mkOption {
         type = types.enum [ "standard" "compact" ];
@@ -16,20 +25,20 @@ in {
       };
     };
 
-  config.gtk.theme = with builtins;
-    with lib;
+  config.gtk.theme =
     let
       flavourUpper = ctp.mkUpper cfg.flavour;
       accentUpper = ctp.mkUpper cfg.accent;
       sizeUpper = ctp.mkUpper cfg.size;
 
       # use the light gtk theme for latte
-      gtkTheme = if cfg.flavour == "latte" then "Light" else "Dark";
-
+      gtkTheme =
+        if cfg.flavour == "latte"
+        then "Light"
+        else "Dark";
     in
-    mkIf cfg.enable {
-      name =
-        "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";
+    lib.mkIf enable {
+      name = "Catppuccin-${flavourUpper}-${sizeUpper}-${accentUpper}-${gtkTheme}";
       package = pkgs.catppuccin-gtk.override {
         inherit (cfg) size tweaks;
         accents = [ cfg.accent ];

--- a/modules/home-manager/helix.nix
+++ b/modules/home-manager/helix.nix
@@ -1,26 +1,40 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.helix.catppuccin;
-in {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (builtins) fromTOML readFile;
+  cfg = config.programs.helix.catppuccin;
+  enable = cfg.enable && config.programs.helix.enable;
+in
+{
   options.programs.helix.catppuccin = with lib;
-    ctp.mkCatppuccinOpt "helix" config // {
+    ctp.mkCatppuccinOpt "helix" config
+    // {
       useItalics = mkEnableOption "Italics in Catppuccin theme for Helix";
     };
 
-  config.programs.helix = with builtins;
-    with lib;
-    with pkgs;
-    let subdir = if cfg.useItalics then "default" else "no_italics";
-    in mkIf cfg.enable {
+  config.programs.helix =
+    let
+      subdir =
+        if cfg.useItalics
+        then "default"
+        else "no_italics";
+    in
+    lib.mkIf enable {
       settings = {
         theme = "catppuccin-${cfg.flavour}";
-        editor.color-modes = mkDefault true;
+        editor.color-modes = lib.mkDefault true;
       };
-      themes."catppuccin-${cfg.flavour}" = fromTOML (readFile (fetchFromGitHub
+
+      themes."catppuccin-${cfg.flavour}" = fromTOML (readFile (pkgs.fetchFromGitHub
         {
           owner = "catppuccin";
           repo = "helix";
           rev = "5677c16dc95297a804caea9161072ff174018fdd";
           sha256 = "sha256-aa8KZ7/1TXcBqaV/TYOZ8rpusOf5QeQ9i2Upnncbziw=";
-        } + "/themes/${subdir}/catppuccin_${cfg.flavour}.toml"));
+        }
+      + "/themes/${subdir}/catppuccin_${cfg.flavour}.toml"));
     };
 }

--- a/modules/home-manager/kitty.nix
+++ b/modules/home-manager/kitty.nix
@@ -1,10 +1,16 @@
-{ config, lib, ... }:
-let cfg = config.programs.kitty.catppuccin;
-in {
+{ config
+, lib
+, ...
+}:
+let
+  inherit (lib) ctp;
+  cfg = config.programs.kitty.catppuccin;
+  enable = cfg.enable && config.programs.kitty.enable;
+in
+{
   options.programs.kitty.catppuccin =
-    lib.ctp.mkCatppuccinOpt "kitty" config;
+    ctp.mkCatppuccinOpt "kitty" config;
 
-  config.programs.kitty = with lib;
-    let flavourUpper = ctp.mkUpper cfg.flavour;
-    in mkIf cfg.enable { theme = "Catppuccin-${flavourUpper}"; };
+  config.programs.kitty =
+    lib.mkIf enable { theme = "Catppuccin-${ctp.mkUpper cfg.flavour}"; };
 }

--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -1,21 +1,27 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.lazygit.catppuccin;
-in {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  cfg = config.programs.lazygit.catppuccin;
+  enable = cfg.enable && config.programs.lazygit.enable;
+in
+{
   options.programs.lazygit.catppuccin =
     lib.ctp.mkCatppuccinOpt "lazygit" config;
 
-  config.programs.lazygit.settings = with builtins;
-    with lib;
-    with pkgs;
+  config.programs.lazygit.settings =
     let
-      file = fetchFromGitHub
-        {
-          owner = "catppuccin";
-          repo = "lazygit";
-          rev = "f01edfd57fa2aa7cd69a92537a613bb3c91e65dd";
-          sha256 = "sha256-zjzDtXcGtUon4QbrZnlAPzngEyH56yy8TCyFv0rIbOA=";
-        } + "/themes/${cfg.flavour}.yml";
-
+      file =
+        pkgs.fetchFromGitHub
+          {
+            owner = "catppuccin";
+            repo = "lazygit";
+            rev = "f01edfd57fa2aa7cd69a92537a613bb3c91e65dd";
+            sha256 = "sha256-zjzDtXcGtUon4QbrZnlAPzngEyH56yy8TCyFv0rIbOA=";
+          }
+        + "/themes/${cfg.flavour}.yml";
     in
-    mkIf cfg.enable (ctp.fromYaml pkgs file);
+    lib.mkIf enable (lib.ctp.fromYaml pkgs file);
 }

--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -1,11 +1,16 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.programs.neovim.catppuccin;
+  enable = cfg.enable && config.programs.neovim.enable;
 in
 {
   options.programs.neovim.catppuccin = lib.ctp.mkCatppuccinOpt "neovim" config;
 
-  config.programs.neovim = with lib; mkIf cfg.enable {
+  config.programs.neovim = lib.mkIf enable {
     plugins = with pkgs.vimPlugins; [
       {
         plugin = catppuccin-nvim;

--- a/modules/home-manager/polybar.nix
+++ b/modules/home-manager/polybar.nix
@@ -1,17 +1,22 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.services.polybar.catppuccin;
-in {
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  cfg = config.services.polybar.catppuccin;
+  enable = cfg.enable && config.services.polybar.enable;
+in
+{
   options.services.polybar.catppuccin =
     lib.ctp.mkCatppuccinOpt "polybar" config;
 
-  config.services.polybar.extraConfig = with builtins;
-    with lib;
-    with pkgs;
-    mkIf cfg.enable (readFile (fetchFromGitHub
-      {
-        owner = "catppuccin";
-        repo = "polybar";
-        rev = "9ee66f83335404186ce979bac32fcf3cd047396a";
-        sha256 = "sha256-bUbSgMg/sa2faeEUZo80GNmhOX3wn2jLzfA9neF8ERA=";
-      } + "/themes/${cfg.flavour}.ini"));
+  config.services.polybar.extraConfig = lib.mkIf enable (builtins.readFile (pkgs.fetchFromGitHub
+    {
+      owner = "catppuccin";
+      repo = "polybar";
+      rev = "9ee66f83335404186ce979bac32fcf3cd047396a";
+      sha256 = "sha256-bUbSgMg/sa2faeEUZo80GNmhOX3wn2jLzfA9neF8ERA=";
+    }
+  + "/themes/${cfg.flavour}.ini"));
 }

--- a/modules/home-manager/starship.nix
+++ b/modules/home-manager/starship.nix
@@ -1,19 +1,30 @@
-{ config, pkgs, lib, ... }:
-let cfg = config.programs.starship.catppuccin; in
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (builtins) fromTOML readFile;
+  cfg = config.programs.starship.catppuccin;
+  enable = cfg.enable && config.programs.starship.enable;
+in
 {
   options.programs.starship.catppuccin =
     lib.ctp.mkCatppuccinOpt "starship" config;
 
-  config.programs.starship.settings = lib.mkIf cfg.enable
-    ({
-      format = lib.mkDefault "$all";
-      palette = "catppuccin_${cfg.flavour}";
-    } // builtins.fromTOML (builtins.readFile
-      (pkgs.fetchFromGitHub
-        {
-          owner = "catppuccin";
-          repo = "starship";
-          rev = "3e3e54410c3189053f4da7a7043261361a1ed1bc";
-          sha256 = "sha256-soEBVlq3ULeiZFAdQYMRFuswIIhI9bclIU8WXjxd7oY=";
-        } + /palettes/${cfg.flavour}.toml)));
+  config.programs.starship.settings =
+    lib.mkIf enable
+      ({
+        format = lib.mkDefault "$all";
+        palette = "catppuccin_${cfg.flavour}";
+      }
+      // fromTOML (readFile
+        (pkgs.fetchFromGitHub
+          {
+            owner = "catppuccin";
+            repo = "starship";
+            rev = "3e3e54410c3189053f4da7a7043261361a1ed1bc";
+            sha256 = "sha256-soEBVlq3ULeiZFAdQYMRFuswIIhI9bclIU8WXjxd7oY=";
+          }
+        + "/palettes/${cfg.flavour}.toml")));
 }

--- a/modules/home-manager/sway.nix
+++ b/modules/home-manager/sway.nix
@@ -1,19 +1,25 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.wayland.windowManager.sway.catppuccin;
-  theme = pkgs.fetchFromGitHub
-    {
-      owner = "catppuccin";
-      repo = "sway";
-      rev = "c89098fc3517b64f0422aaaccb98dcab6ae9348f";
-      sha256 = "sha256-6Cvsmdl3OILz1vZovyBIuuSpm207I3W0dmUGowR9Ugk=";
-    } + "/themes/catppuccin-${cfg.flavour}";
+  enable = cfg.enable && config.wayland.windowManager.sway.enable;
+  theme =
+    pkgs.fetchFromGitHub
+      {
+        owner = "catppuccin";
+        repo = "sway";
+        rev = "c89098fc3517b64f0422aaaccb98dcab6ae9348f";
+        sha256 = "sha256-6Cvsmdl3OILz1vZovyBIuuSpm207I3W0dmUGowR9Ugk=";
+      }
+    + "/themes/catppuccin-${cfg.flavour}";
 in
 {
   options.wayland.windowManager.sway.catppuccin =
     lib.ctp.mkCatppuccinOpt "sway" config;
 
-  config.wayland.windowManager.sway.extraConfigEarly = with lib;
-    with builtins;
-    mkIf cfg.enable (readFile theme);
+  config.wayland.windowManager.sway.extraConfigEarly =
+    lib.mkIf enable (builtins.readFile theme);
 }

--- a/modules/home-manager/tmux.nix
+++ b/modules/home-manager/tmux.nix
@@ -1,11 +1,17 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.programs.tmux.catppuccin;
+  enable = cfg.enable && config.programs.tmux.enable;
 
   plugin = with builtins;
-    with pkgs;
-    let rev = "4e48b09a76829edc7b55fbb15467cf0411f07931";
-    in tmuxPlugins.mkTmuxPlugin {
+    with pkgs; let
+      rev = "4e48b09a76829edc7b55fbb15467cf0411f07931";
+    in
+    tmuxPlugins.mkTmuxPlugin {
       pluginName = "catppuccin";
       version = substring 0 7 rev;
       src = fetchFromGitHub {
@@ -20,7 +26,7 @@ in
   options.programs.tmux.catppuccin =
     lib.ctp.mkCatppuccinOpt "tmux" config;
 
-  config.programs.tmux.plugins = with lib; mkIf cfg.enable [
+  config.programs.tmux.plugins = lib.mkIf enable [
     {
       inherit plugin;
       extraConfig = "set -g @catppuccin_flavour '${cfg.flavour}'";

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -1,34 +1,23 @@
 lib:
-with builtins;
-with lib; rec {
-  # string -> string
-  # this capitalizes the first letter in a string,
-  # which is sometimes needed in order to format
-  # the names of themes correctly
-  mkUpper = str:
-    (toUpper (substring 0 1 str)) + (substring 1 (stringLength str) str);
+let
+  # string -> type -> string -> a -> a
+  # this is an internal function and shouldn't be
+  # used unless you know what you're doing. it takes
+  # a string (the name of the property, i.e., flavour
+  # or accent), the type of the property, the name of
+  # the module, followed by local config attrset
+  mkBasicOpt = attr: type: name: config:
+    lib.mkOption {
+      inherit type;
+      default = config.catppuccin.${attr};
+      description = "Catppuccin ${attr} for ${name}";
+    };
 
-  # a -> path -> a
-  # fromJSON but for yaml (and without readFile)
-  # a should be the local pkgs attrset
-  fromYaml = pkgs: file:
-    let
-      # convert to json
-      json = with pkgs; runCommand "converted.json" { } ''
-        ${yj}/bin/yj < ${file} > $out
-      '';
-    in
-    fromJSON (readFile json);
-
-  # a -> a -> [path] -> [path]
-  # this imports a list of paths while inheriting
-  # multiple attributes
-  mapModules = config: pkgs: extendedLib:
-    map (m:
-      (import m {
-        inherit config pkgs;
-        lib = extendedLib;
-      }));
+  # string -> a -> a
+  # this creates a flavour option for modules
+  # the first string should be the name of the module,
+  # followed by the local config attrset
+  mkFlavourOpt = mkBasicOpt "flavour" types.flavourOption;
 
   types = {
     flavourOption = lib.types.enum [ "latte" "frappe" "macchiato" "mocha" ];
@@ -49,31 +38,41 @@ with lib; rec {
       "yellow"
     ];
   };
+in
+{
+  inherit mkBasicOpt mkFlavourOpt types;
 
-  # string -> type -> string -> a -> a
-  # this is an internal function and shouldn't be
-  # used unless you know what you're doing. it takes
-  # a string (the name of the property, i.e., flavour
-  # or accent), the type of the property, the name of
-  # the module, followed by local config attrset
-  mkBasicOpt = attr: type: name: config:
-    mkOption {
-      inherit type;
-      default = config.catppuccin.${attr};
-      description = "Catppuccin ${attr} for ${name}";
-    };
+  # string -> string
+  # this capitalizes the first letter in a string,
+  # which is sometimes needed in order to format
+  # the names of themes correctly
+  mkUpper = str:
+    with builtins;
+    (lib.toUpper (substring 0 1 str)) + (substring 1 (stringLength str) str);
 
-  # string -> a -> a
-  # this creates a flavour option for modules
-  # the first string should be the name of the module,
-  # followed by the local config attrset
-  mkFlavourOpt = mkBasicOpt "flavour" types.flavourOption;
+  # a -> path -> a
+  # fromJSON but for yaml (and without readFile)
+  # a should be the local pkgs attrset
+  fromYaml = pkgs: file:
+    let
+      inherit (builtins) fromJSON readFile;
 
-  # string -> a -> a
-  # this creates an accent option for modules
-  # the first string should be the name of the module,
-  # followed by the local config attrset
-  mkAccentOpt = mkBasicOpt "accent" types.accentOption;
+      # convert to json
+      json = with pkgs;
+        runCommand "converted.json" { } ''
+          ${yj}/bin/yj < ${file} > $out
+        '';
+    in
+    fromJSON (readFile json);
+
+  # a -> a -> [path] -> [path]
+  # this imports a list of paths while inheriting
+  # multiple attributes
+  mapModules = config: pkgs: extendedLib:
+    map (m: (import m {
+      inherit config pkgs;
+      lib = extendedLib;
+    }));
 
   # string -> a -> a
   # this creates a basic attrset only containing an
@@ -81,7 +80,13 @@ with lib; rec {
   # be the name of the module, followed by the local config
   # attrset
   mkCatppuccinOpt = name: config: {
-    enable = mkEnableOption "Catppuccin theme";
+    enable = lib.mkEnableOption "Catppuccin theme";
     flavour = mkFlavourOpt name config;
   };
+
+  # string -> a -> a
+  # this creates an accent option for modules
+  # the first string should be the name of the module,
+  # followed by the local config attrset
+  mkAccentOpt = mkBasicOpt "accent" types.accentOption;
 }

--- a/modules/lib/mkExtLib.nix
+++ b/modules/lib/mkExtLib.nix
@@ -1,1 +1,1 @@
-lib: with builtins; lib.extend (self: _: { ctp = import ./. self; })
+lib: lib.extend (self: _: { ctp = import ./. self; })

--- a/modules/nixos/grub.nix
+++ b/modules/nixos/grub.nix
@@ -1,26 +1,30 @@
-{ config, pkgs, lib, ... }:
+{ config
+, pkgs
+, lib
+, ...
+}:
 let
   cfg = config.boot.loader.grub.catppuccin;
+  enable = cfg.enable && config.boot.loader.grub.enable;
 
-  theme = with pkgs;
-    let
-      src = fetchFromGitHub {
-        owner = "catppuccin";
-        repo = "grub";
-        rev = "803c5df0e83aba61668777bb96d90ab8f6847106";
-        sha256 = "sha256-/bSolCta8GCZ4lP0u5NVqYQ9Y3ZooYCNdTwORNvR7M0=";
-      };
-    in
-    runCommand "catppuccin-grub-theme" { } ''
-      mkdir -p "$out"
-      cp -r ${src}/src/catppuccin-${cfg.flavour}-grub-theme/* "$out"/
-    '';
+  theme = with pkgs; let
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "grub";
+      rev = "803c5df0e83aba61668777bb96d90ab8f6847106";
+      sha256 = "sha256-/bSolCta8GCZ4lP0u5NVqYQ9Y3ZooYCNdTwORNvR7M0=";
+    };
+  in
+  runCommand "catppuccin-grub-theme" { } ''
+    mkdir -p "$out"
+    cp -r ${src}/src/catppuccin-${cfg.flavour}-grub-theme/* "$out"/
+  '';
 in
 {
   options.boot.loader.grub.catppuccin =
     lib.ctp.mkCatppuccinOpt "grub" config;
 
-  config.boot.loader.grub = with lib; mkIf cfg.enable {
+  config.boot.loader.grub = lib.mkIf enable {
     font = "${theme}/font.pf2";
     splashImage = "${theme}/background.png";
     inherit theme;


### PR DESCRIPTION
this is a redo of (part of) https://github.com/Stonks3141/ctp-nix/pull/1. i'm trying to find a better middle ground here, as `with` has gotten pretty annoying (especially when we use it three times in a row) and i feel has had the opposite effect on readability than intended. it is also a bit of [anti-pattern](https://nix.dev/recipes/best-practices#with-scopes). 

this _doesn't_ use `let inherit ..; in` nearly as much, but does at times when a certain attribute - `lib.ctp` for example - are used twice or more. in other circumstances, attributes are explicitly brought into scope to try to make where they're coming from much more obvious and reduce unnecessary `inherits`. finally, `lib/default.nix` has also seen some work to avoid the weirdness of `rec`, another [anti-pattern](https://nix.dev/recipes/best-practices#recursive-attribute-set-rec). i hope this is a good spot in between having to look at two different places for the origin of functions, while also not making modules too verbose or not verbose enough.

this also includes a fix for a small oversight where `catppuccin.enable` would trigger the effects of the module, without the parent modules being enabled. an example of this would be this attrset

```nix
programs.btop = {
  enable = false;
  catppuccin.enable = true;
};
```

causing `xdg.enable` to be set to true and the theme dropped in `xdgConfigFile."btop/themes`, even though btop itself is not actually enabled.

## NOTE
this is based on https://github.com/Stonks3141/ctp-nix/pull/37 so that should be merged first