### PR TITLE
add autogenerated docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,41 @@
+name: Update docs
+
+on:
+  push:
+    paths:
+      - "modules/home-manager/**"
+      - "modules/nixos/**"
+
+permissions:
+  contents: write
+
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        package: ["nixos", "home-manager"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
+
+      - name: Build doc
+        run: nix build .#${{ matrix.package }}-doc
+
+      - name: Update doc
+        run: cat result > docs/${{ matrix.package }}-options.md
+
+      - name: Get short revision
+        id: rev
+        run:
+          echo "rev=$(git rev parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          default_author: github_actions
+          message: "docs: update docs for ${{ steps.rev.outputs.rev }}"

--- a/docs/home-manager-options.md
+++ b/docs/home-manager-options.md
@@ -1,0 +1,584 @@
+## catppuccin\.accent
+
+Global Catppuccin accent
+
+*Type:*
+one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, “mauve”, “peach”, “pink”, “red”, “rosewater”, “sapphire”, “sky”, “teal”, “yellow”
+
+
+
+*Default:*
+` "teal" `
+
+
+
+## catppuccin\.flavour
+
+Global Catppuccin flavour
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## gtk\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## gtk\.catppuccin\.accent
+
+Catppuccin accent for gtk
+
+
+
+*Type:*
+one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, “mauve”, “peach”, “pink”, “red”, “rosewater”, “sapphire”, “sky”, “teal”, “yellow”
+
+
+
+*Default:*
+` "teal" `
+
+
+
+## gtk\.catppuccin\.flavour
+
+Catppuccin flavour for gtk
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## gtk\.catppuccin\.size
+
+Catppuccin size variant for gtk
+
+
+
+*Type:*
+one of “standard”, “compact”
+
+
+
+*Default:*
+` "standard" `
+
+
+
+## gtk\.catppuccin\.tweaks
+
+Catppuccin tweaks for gtk
+
+
+
+*Type:*
+list of (one of “black”, “rimless”, “normal”)
+
+
+
+*Default:*
+
+```
+[
+  "normal"
+]
+```
+
+
+
+## programs\.alacritty\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.alacritty\.catppuccin\.flavour
+
+Catppuccin flavour for alacritty
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.bat\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.bat\.catppuccin\.flavour
+
+Catppuccin flavour for bat
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.bottom\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.bottom\.catppuccin\.flavour
+
+Catppuccin flavour for bottom
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.btop\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.btop\.catppuccin\.flavour
+
+Catppuccin flavour for btop
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.helix\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.helix\.catppuccin\.flavour
+
+Catppuccin flavour for helix
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.helix\.catppuccin\.useItalics
+
+Whether to enable Italics in Catppuccin theme for Helix.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.kitty\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.kitty\.catppuccin\.flavour
+
+Catppuccin flavour for kitty
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.lazygit\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.lazygit\.catppuccin\.flavour
+
+Catppuccin flavour for lazygit
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.neovim\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.neovim\.catppuccin\.flavour
+
+Catppuccin flavour for neovim
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.starship\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.starship\.catppuccin\.flavour
+
+Catppuccin flavour for starship
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.tmux\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.tmux\.catppuccin\.flavour
+
+Catppuccin flavour for tmux
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## services\.polybar\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## services\.polybar\.catppuccin\.flavour
+
+Catppuccin flavour for polybar
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## wayland\.windowManager\.sway\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## wayland\.windowManager\.sway\.catppuccin\.flavour
+
+Catppuccin flavour for sway
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+

--- a/docs/nixos-options.md
+++ b/docs/nixos-options.md
@@ -1,0 +1,50 @@
+## boot\.loader\.grub\.catppuccin\.enable
+
+Whether to enable Catppuccin theme.
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## boot\.loader\.grub\.catppuccin\.flavour
+
+Catppuccin flavour for grub
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## catppuccin\.flavour
+
+Global Catppuccin flavour
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     };
   };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { self, nixpkgs, ... }:
     let
       systems = [
         "x86_64-linux"
@@ -17,18 +17,51 @@
         "aarch64-darwin"
       ];
 
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-      forEachSystem = fn:
-        forAllSystems (system:
-          fn {
-            inherit system;
-            pkgs = nixpkgsFor.${system};
-          });
+      inherit (nixpkgs) lib;
+
+      forAllSystems = fn: lib.genAttrs systems (s: fn nixpkgsFor.${s});
+      nixpkgsFor = lib.genAttrs systems (system: import nixpkgs { inherit system; });
     in
     {
-      nixosModules.catppuccin = import ./modules/nixos nixpkgs;
+      formatter = forAllSystems (pkgs: pkgs.nixpkgs-fmt);
+
       homeManagerModules.catppuccin = import ./modules/home-manager nixpkgs;
-      formatter = forEachSystem ({ pkgs, ... }: pkgs.nixpkgs-fmt);
+
+      nixosModules.catppuccin = import ./modules/nixos nixpkgs;
+
+      packages = forAllSystems (pkgs:
+        let
+          mkEval = module: lib.evalModules {
+            modules = [
+              module
+              {
+                _module = {
+                  check = false;
+                  args.lib = import ./modules/lib/mkExtLib.nix lib;
+                };
+              }
+            ];
+          };
+
+          mkDoc = name: options:
+            let
+              doc = pkgs.nixosOptionsDoc {
+                options = lib.filterAttrs (n: _: n != "_module") options;
+                documentType = "none";
+                revision = if self ? rev then builtins.substring 0 7 self.rev else "dirty";
+              };
+            in
+            pkgs.runCommand "${name}-module-doc.md" { } ''
+              cat ${doc.optionsCommonMark} > $out
+            '';
+
+          hmEval = mkEval self.homeManagerModules.catppuccin;
+          nixosEval = mkEval self.nixosModules.catppuccin;
+        in
+        rec {
+          nixos-doc = mkDoc "nixos" nixosEval.options;
+          home-manager-doc = mkDoc "home-manager" hmEval.options;
+          default = home-manager-doc;
+        });
     };
 }


### PR DESCRIPTION
this uses `nixosOptionDoc` to automatically create options from our modules. currently, this outputs as commonmark - which i think is ok for now - but this could be expanded to something such as a website with `mkDocs` if preferred

[home-manager options rendered](https://github.com/Stonks3141/ctp-nix/blob/a787926876bf932f7d1f839676ec8f7e02bc5dab/docs/home-manager-options.md)
[nixos options rendered](https://github.com/Stonks3141/ctp-nix/blob/a787926876bf932f7d1f839676ec8f7e02bc5dab/docs/nixos-options.md)
