### PR TITLE
feat(modules/home-manager): add glamour

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -19,6 +19,7 @@ in
         ./lazygit.nix
         ./starship.nix
         ./helix.nix
+        ./glamour.nix
         ./gtk.nix
         ./neovim.nix
         ./polybar.nix

--- a/modules/home-manager/glamour.nix
+++ b/modules/home-manager/glamour.nix
@@ -1,0 +1,31 @@
+{ config
+, pkgs
+, lib
+,
+}:
+let
+  cfg = config.programs.glamour.catppuccin;
+  enable = cfg.enable;
+
+  version = "1.0.0";
+
+  hashes = {
+    latte = "sha256-V0LsRStF1vL+Tz8G6VaKiwiY/ZIsSkMc+f1WJAITYXU=";
+    frappe = "sha256-YOatgYCJKuesVERHZVmF1xtzuLjyxCYstoWYqATq+NU=";
+    macchiato = "sha256-CeSJvhjzHVTtlqgQLKOrdLXtp2OQlMh24IaA1QQiQCk=";
+    mocha = "sha256-Tx2fQteL4wxhV+qHYZibakiYoEhS4HjyMO0yBcU/F6Q=";
+  };
+in
+{
+  options.programs.glamour.catppuccin =
+    lib.ctp.mkCatppuccinOpt "glamour" config;
+
+  config = {
+    home.sessionVariables = lib.mkIf enable {
+      GLAMOUR_STYLE = pkgs.fetchurl {
+        url = "https://github.com/catppuccin/glamour/releases/download/v${version}/${cfg.flavour}.json";
+        hash = hashes.${cfg.flavour};
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds support for [glamour](https://github.com/charmbracelet/glamour), a Markdown rendering library used in a variety of Go CLIs (including `gh` and `glow`).