### PR TITLE
feat(home-manager): init mako module

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -22,6 +22,7 @@ in
         ./helix.nix
         ./glamour.nix
         ./gtk.nix
+        ./mako.nix
         ./neovim.nix
         ./polybar.nix
         ./sway.nix

--- a/modules/home-manager/mako.nix
+++ b/modules/home-manager/mako.nix
@@ -1,0 +1,34 @@
+{ config
+, pkgs
+, lib
+, ...
+}:
+let
+  inherit (builtins) readFile;
+
+  cfg = config.services.mako.catppuccin;
+  enable = cfg.enable && config.services.mako.enable;
+  theme = lib.ctp.fromINI pkgs (pkgs.fetchFromGitHub
+    {
+      owner = "catppuccin";
+      repo = "mako";
+      rev = "9dd088aa5f4529a3dd4d9760415e340664cb86df";
+      hash = "sha256-nUzWkQVsIH4rrCFSP87mXAka6P+Td2ifNbTuP7NM/SQ=";
+    } + /src/${cfg.flavour});
+
+  # Settings that need to be extracted and put in extraConfig
+  extraConfigAttrs = lib.attrsets.getAttrs [ "urgency=high" ] theme;
+in
+{
+  options.services.mako.catppuccin =
+    lib.ctp.mkCatppuccinOpt "mako" config;
+
+  # Will cause infinite recursion if config.services.mako is directly set as a whole
+  config.services.mako = lib.mkIf enable {
+    backgroundColor = theme.background-color;
+    textColor = theme.text-color;
+    borderColor = theme.border-color;
+    progressColor = theme.progress-color;
+    extraConfig = readFile ((pkgs.formats.ini { }).generate "mako-extra-config" extraConfigAttrs);
+  };
+}

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -65,6 +65,21 @@ in
     in
     fromJSON (readFile json);
 
+  # a -> path -> a
+  # fromJSON but for ini (and without readFile)
+  # a should be the local pkgs attrset
+  fromINI = pkgs: file:
+    let
+      inherit (builtins) fromJSON readFile;
+
+      # convert to json
+      json = with pkgs;
+        runCommand "converted.json" { } ''
+          ${jc}/bin/jc --ini < ${file} > $out
+        '';
+    in
+    fromJSON (readFile json);
+
   # a -> a -> [path] -> [path]
   # this imports a list of paths while inheriting
   # multiple attributes


### PR DESCRIPTION
Adds support for mako. Resolves #16.

I also took the liberty of adding a helper function, `fromINI`, to `lib`.