### PR TITLE
feat(home-manager): init swaylock module

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -339,6 +339,26 @@
         },
         "version": "c976222e5cacbba7946fb82163944924bd5fac12"
     },
+    "swaylock": {
+        "cargoLocks": null,
+        "date": "2023-02-10",
+        "extract": null,
+        "name": "swaylock",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "remiposo",
+            "repo": "swaylock",
+            "rev": "9b88d9e866c044d47c98046ee6c8d6de2546cf82",
+            "sha256": "sha256-v2op7V52VYqzY9govnfkgmF7ybRRlPkohgnrUWDjItI=",
+            "type": "github"
+        },
+        "version": "9b88d9e866c044d47c98046ee6c8d6de2546cf82"
+    },
     "tmux": {
         "cargoLocks": null,
         "date": "2023-11-01",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -205,6 +205,18 @@
     };
     date = "2023-08-20";
   };
+  swaylock = {
+    pname = "swaylock";
+    version = "9b88d9e866c044d47c98046ee6c8d6de2546cf82";
+    src = fetchFromGitHub {
+      owner = "remiposo";
+      repo = "swaylock";
+      rev = "9b88d9e866c044d47c98046ee6c8d6de2546cf82";
+      fetchSubmodules = false;
+      sha256 = "sha256-v2op7V52VYqzY9govnfkgmF7ybRRlPkohgnrUWDjItI=";
+    };
+    date = "2023-02-10";
+  };
   tmux = {
     pname = "tmux";
     version = "47e33044b4b47b1c1faca1e42508fc92be12131a";

--- a/docs/home-manager-options.md
+++ b/docs/home-manager-options.md
@@ -2,6 +2,8 @@
 
 Global Catppuccin accent
 
+
+
 *Type:*
 one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, “mauve”, “peach”, “pink”, “red”, “rosewater”, “sapphire”, “sky”, “teal”, “yellow”
 
@@ -13,6 +15,8 @@ one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, �
 
 
 ## catppuccin\.flavour
+
+
 
 Global Catppuccin flavour
 
@@ -30,7 +34,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## gtk\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -51,6 +57,8 @@ boolean
 
 ## gtk\.catppuccin\.accent
 
+
+
 Catppuccin accent for gtk
 
 
@@ -66,6 +74,8 @@ one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, �
 
 
 ## gtk\.catppuccin\.flavour
+
+
 
 Catppuccin flavour for gtk
 
@@ -83,6 +93,8 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## gtk\.catppuccin\.size
 
+
+
 Catppuccin size variant for gtk
 
 
@@ -98,6 +110,8 @@ one of “standard”, “compact”
 
 
 ## gtk\.catppuccin\.tweaks
+
+
 
 Catppuccin tweaks for gtk
 
@@ -120,7 +134,9 @@ list of (one of “black”, “rimless”, “normal”)
 
 ## programs\.alacritty\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -141,6 +157,8 @@ boolean
 
 ## programs\.alacritty\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for alacritty
 
 
@@ -157,7 +175,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.bat\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -178,6 +198,8 @@ boolean
 
 ## programs\.bat\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for bat
 
 
@@ -194,7 +216,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.bottom\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -215,6 +239,8 @@ boolean
 
 ## programs\.bottom\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for bottom
 
 
@@ -231,7 +257,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.btop\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -252,7 +280,91 @@ boolean
 
 ## programs\.btop\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for btop
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.fish\.catppuccin\.enable
+
+
+
+Whether to enable Catppuccin theme\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.fish\.catppuccin\.flavour
+
+
+
+Catppuccin flavour for fish
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.glamour\.catppuccin\.enable
+
+
+
+Whether to enable Catppuccin theme\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.glamour\.catppuccin\.flavour
+
+
+
+Catppuccin flavour for glamour
 
 
 
@@ -268,7 +380,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.helix\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -289,6 +403,8 @@ boolean
 
 ## programs\.helix\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for helix
 
 
@@ -305,7 +421,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.helix\.catppuccin\.useItalics
 
-Whether to enable Italics in Catppuccin theme for Helix.
+
+
+Whether to enable Italics in Catppuccin theme for Helix\.
 
 
 
@@ -326,7 +444,9 @@ boolean
 
 ## programs\.kitty\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -347,6 +467,8 @@ boolean
 
 ## programs\.kitty\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for kitty
 
 
@@ -363,7 +485,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.lazygit\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -382,7 +506,27 @@ boolean
 
 
 
+## programs\.lazygit\.catppuccin\.accent
+
+
+
+Catppuccin accent for lazygit
+
+
+
+*Type:*
+one of “blue”, “flamingo”, “green”, “lavender”, “maroon”, “mauve”, “peach”, “pink”, “red”, “rosewater”, “sapphire”, “sky”, “teal”, “yellow”
+
+
+
+*Default:*
+` "teal" `
+
+
+
 ## programs\.lazygit\.catppuccin\.flavour
+
+
 
 Catppuccin flavour for lazygit
 
@@ -398,9 +542,52 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 
 
+## programs\.micro\.catppuccin\.enable
+
+
+
+Whether to enable Catppuccin theme\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.micro\.catppuccin\.flavour
+
+
+
+Catppuccin flavour for micro
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
 ## programs\.neovim\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -421,6 +608,8 @@ boolean
 
 ## programs\.neovim\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for neovim
 
 
@@ -437,7 +626,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.starship\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -458,7 +649,50 @@ boolean
 
 ## programs\.starship\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for starship
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## programs\.swaylock\.catppuccin\.enable
+
+
+
+Whether to enable Catppuccin theme\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## programs\.swaylock\.catppuccin\.flavour
+
+
+
+Catppuccin flavour for swaylock
 
 
 
@@ -474,7 +708,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## programs\.tmux\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -495,7 +731,50 @@ boolean
 
 ## programs\.tmux\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for tmux
+
+
+
+*Type:*
+one of “latte”, “frappe”, “macchiato”, “mocha”
+
+
+
+*Default:*
+` "latte" `
+
+
+
+## services\.mako\.catppuccin\.enable
+
+
+
+Whether to enable Catppuccin theme\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+*Example:*
+` true `
+
+
+
+## services\.mako\.catppuccin\.flavour
+
+
+
+Catppuccin flavour for mako
 
 
 
@@ -511,7 +790,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## services\.polybar\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -532,6 +813,8 @@ boolean
 
 ## services\.polybar\.catppuccin\.flavour
 
+
+
 Catppuccin flavour for polybar
 
 
@@ -548,7 +831,9 @@ one of “latte”, “frappe”, “macchiato”, “mocha”
 
 ## wayland\.windowManager\.sway\.catppuccin\.enable
 
-Whether to enable Catppuccin theme.
+
+
+Whether to enable Catppuccin theme\.
 
 
 
@@ -568,6 +853,8 @@ boolean
 
 
 ## wayland\.windowManager\.sway\.catppuccin\.flavour
+
+
 
 Catppuccin flavour for sway
 

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -23,6 +23,7 @@ in
         ./micro.nix
         ./polybar.nix
         ./sway.nix
+        ./swaylock.nix
         ./tmux.nix
       ];
     in

--- a/modules/home-manager/swaylock.nix
+++ b/modules/home-manager/swaylock.nix
@@ -1,0 +1,16 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  cfg = config.programs.swaylock.catppuccin;
+  enable = cfg.enable && config.programs.swaylock.enable;
+in
+{
+  options.programs.swaylock.catppuccin =
+    lib.ctp.mkCatppuccinOpt "swaylock";
+
+  config.programs.swaylock.settings = lib.mkIf enable
+    (lib.ctp.fromINI (sources.swaylock + /themes/${cfg.flavour}.conf));
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -66,6 +66,10 @@ fetch.github = "catppuccin/starship"
 src.git = "https://github.com/catppuccin/sway.git"
 fetch.github = "catppuccin/sway"
 
+[swaylock]
+src.git = "https://github.com/remiposo/swaylock.git"
+fetch.github = "remiposo/swaylock"
+
 [tmux]
 src.git = "https://github.com/catppuccin/tmux.git"
 fetch.github = "catppuccin/tmux"


### PR DESCRIPTION
Adds support for swaylock.

In case it matters, this theme is from a third-party repo rather than one owned by the Catppuccin GitHub organization.