### PR TITLE
feat(home-manager): init hyprland module

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -179,6 +179,26 @@
         },
         "version": "8313c7250fcbbb22c6680db332669073ec6b28c2"
     },
+    "hyprland": {
+        "cargoLocks": null,
+        "date": "2023-05-03",
+        "extract": null,
+        "name": "hyprland",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "hyprland",
+            "rev": "99a88fd21fac270bd999d4a26cf0f4a4222c58be",
+            "sha256": "sha256-07B5QmQmsUKYf38oWU3+2C6KO4JvinuTwmW1Pfk8CT8=",
+            "type": "github"
+        },
+        "version": "99a88fd21fac270bd999d4a26cf0f4a4222c58be"
+    },
     "kitty": {
         "cargoLocks": null,
         "date": "2023-06-09",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -109,6 +109,18 @@
     };
     date = "2023-10-20";
   };
+  hyprland = {
+    pname = "hyprland";
+    version = "99a88fd21fac270bd999d4a26cf0f4a4222c58be";
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "hyprland";
+      rev = "99a88fd21fac270bd999d4a26cf0f4a4222c58be";
+      fetchSubmodules = false;
+      sha256 = "sha256-07B5QmQmsUKYf38oWU3+2C6KO4JvinuTwmW1Pfk8CT8=";
+    };
+    date = "2023-05-03";
+  };
   kitty = {
     pname = "kitty";
     version = "4820b3ef3f4968cf3084b2239ce7d1e99ea04dda";

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -16,6 +16,7 @@ in
         ./lazygit.nix
         ./starship.nix
         ./helix.nix
+        ./hyprland.nix
         ./glamour.nix
         ./gtk.nix
         ./mako.nix

--- a/modules/home-manager/hyprland.nix
+++ b/modules/home-manager/hyprland.nix
@@ -1,0 +1,19 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  cfg = config.wayland.windowManager.hyprland.catppuccin;
+  enable = cfg.enable && config.wayland.windowManager.hyprland.enable;
+in
+{
+  options.wayland.windowManager.hyprland.catppuccin =
+    lib.ctp.mkCatppuccinOpt "hyprland";
+
+  # Because of how nix merges options and hyprland interprets options, sourcing
+  # the file does not work. instead, parse the theme and put it in settings so
+  # the variables appear early enough in the file to be applied properly.
+  config.wayland.windowManager.hyprland.settings = lib.mkIf enable
+    (lib.ctp.fromINI (sources.hyprland + /themes/${cfg.flavour}.conf));
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -34,6 +34,10 @@ fetch.github = "catppuccin/gtk"
 src.git = "https://github.com/catppuccin/helix.git"
 fetch.github = "catppuccin/helix"
 
+[hyprland]
+src.git = "https://github.com/catppuccin/hyprland.git"
+fetch.github = "catppuccin/hyprland"
+
 [kitty]
 src.git = "https://github.com/catppuccin/kitty.git"
 fetch.github = "catppuccin/kitty"

--- a/test.nix
+++ b/test.nix
@@ -80,6 +80,7 @@ in
       };
 
       wayland.windowManager.sway = ctpEnable;
+      wayland.windowManager.hyprland = ctpEnable;
     };
   };
 


### PR DESCRIPTION
Adds support for Hyprland.

Rather than just adding a `source` statement for the theme, I had to resort to parsing the theme and individually adding the variables to `wayland.windowManager.hyprland.settings` due to quirks in how nix and the hyprland home-manager module work. 

Unfortunately, I doubt these quirks are going to be fixed any time soon: https://github.com/nix-community/home-manager/pull/4263/files#r1271640239