### PR TITLE
refactor(home-manager): ensure xdg.enable using assertion

### DIFF
--- a/modules/home-manager/btop.nix
+++ b/modules/home-manager/btop.nix
@@ -17,11 +17,11 @@ in
 
   config = lib.mkIf enable
     {
-      xdg = {
-        # xdg is required for this to work
-        enable = lib.mkForce true;
-        configFile."btop${themePath}".source = theme;
-      };
+      assertions = [
+        (lib.ctp.assertXdgEnabled "btop")
+      ];
+
+      xdg.configFile."btop${themePath}".source = theme;
 
       programs.btop.settings.color_theme = themeFile;
     };

--- a/modules/home-manager/fish.nix
+++ b/modules/home-manager/fish.nix
@@ -14,13 +14,12 @@ in
 {
   options.programs.fish.catppuccin = lib.ctp.mkCatppuccinOpt "fish";
 
-  # xdg is required for this to work
   config = mkIf enable {
-    xdg = {
-      enable = lib.mkForce true;
+    assertions = [
+      (lib.ctp.assertXdgEnabled "fish")
+    ];
 
-      configFile."fish${themePath}".source = "${sources.fish}${themePath}";
-    };
+    xdg.configFile."fish${themePath}".source = "${sources.fish}${themePath}";
 
     programs.fish.shellInit = ''
       fish_config theme choose "${themeName}"

--- a/modules/home-manager/micro.nix
+++ b/modules/home-manager/micro.nix
@@ -14,12 +14,12 @@ in
     lib.ctp.mkCatppuccinOpt "micro";
 
   config = lib.mkIf enable {
+    assertions = [
+      (lib.ctp.assertXdgEnabled "micro")
+    ];
+
     programs.micro.settings.colorscheme = lib.removeSuffix ".micro" themePath;
 
-    xdg = {
-      # xdg is required for this to work
-      enable = lib.mkForce true;
-      configFile."micro/colorschemes/${themePath}".source = "${sources.micro}/src/${themePath}";
-    };
+    xdg.configFile."micro/colorschemes/${themePath}".source = "${sources.micro}/src/${themePath}";
   };
 }

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -105,4 +105,9 @@ in
   # the first string should be the name of the module,
   # followed by the local config attrset
   mkAccentOpt = mkBasicOpt "accent" types.accentOption;
+
+  assertXdgEnabled = name: {
+    assertion = config.xdg.enable;
+    message = "Option xdg.enable must be enabled to apply Catppuccin theming for ${name}";
+  };
 }

--- a/test.nix
+++ b/test.nix
@@ -42,6 +42,8 @@ in
 
       inherit (common) catppuccin;
 
+      xdg.enable = true;
+
       home = {
         username = "test";
         stateVersion = lib.mkDefault "23.11";


### PR DESCRIPTION
I don't think it's nice to enable options like these for the user. Instead we should just tell them to do it in their config.
