### PR TITLE
fix(home-manager/bat): wrong themeName

### DIFF
--- a/modules/home-manager/bat.nix
+++ b/modules/home-manager/bat.nix
@@ -6,7 +6,7 @@
 let
   cfg = config.programs.bat.catppuccin;
   enable = cfg.enable && config.programs.bat.enable;
-  themeName = "Catppuccin-${cfg.flavour}";
+  themeName = "catppuccin-${cfg.flavour}";
 in
 {
   options.programs.bat.catppuccin =


### PR DESCRIPTION
fix warning of bat:
>[bat warning]: Unknown theme 'Catppuccin-mocha', using default.

solve #67 

## my test
no warning with this pr
<img width="303" alt="image" src="https://github.com/Stonks3141/ctp-nix/assets/48193000/df14b5cf-42e3-4aeb-8e5c-1ff15ec2e44a">
