### PR TITLE
feat(nixos): init console module

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -299,6 +299,26 @@
         },
         "version": "40dc9f0621c55bd40da4ad0731fac44d15bb393a"
     },
+    "palette": {
+        "cargoLocks": null,
+        "date": "2024-01-02",
+        "extract": null,
+        "name": "palette",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "catppuccin",
+            "repo": "palette",
+            "rev": "7f103c3e11f7f705ee1fb8ac430d90a798bbdfcb",
+            "sha256": "sha256-W1Bj/407i2XT7CmCBoFe2PCe10MB8lmnEQsWXSrJ6zg=",
+            "type": "github"
+        },
+        "version": "7f103c3e11f7f705ee1fb8ac430d90a798bbdfcb"
+    },
     "polybar": {
         "cargoLocks": null,
         "date": "2022-10-05",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -181,6 +181,18 @@
     };
     date = "2023-11-01";
   };
+  palette = {
+    pname = "palette";
+    version = "7f103c3e11f7f705ee1fb8ac430d90a798bbdfcb";
+    src = fetchFromGitHub {
+      owner = "catppuccin";
+      repo = "palette";
+      rev = "7f103c3e11f7f705ee1fb8ac430d90a798bbdfcb";
+      fetchSubmodules = false;
+      sha256 = "sha256-W1Bj/407i2XT7CmCBoFe2PCe10MB8lmnEQsWXSrJ6zg=";
+    };
+    date = "2024-01-02";
+  };
   polybar = {
     pname = "polybar";
     version = "9ee66f83335404186ce979bac32fcf3cd047396a";

--- a/modules/nixos/console.nix
+++ b/modules/nixos/console.nix
@@ -1,0 +1,38 @@
+{ config
+, lib
+, sources
+, ...
+}:
+let
+  cfg = config.console.catppuccin;
+  enable = cfg.enable && config.console.enable;
+  palette = (lib.importJSON "${sources.palette}/palette.json").${cfg.flavour}.colors;
+in
+{
+  options.console.catppuccin =
+    lib.ctp.mkCatppuccinOpt "console";
+
+  config.console.colors = lib.mkIf enable (
+    # Manually populate with colors from catppuccin/tty
+    # Make sure to strip initial # from hex codes
+    map (color: (builtins.substring 1 6 palette.${color}.hex)) [
+      "base"
+      "red"
+      "green"
+      "yellow"
+      "blue"
+      "pink"
+      "teal"
+      "subtext1"
+
+      "surface2"
+      "red"
+      "green"
+      "yellow"
+      "blue"
+      "pink"
+      "teal"
+      "subtext0"
+    ]
+  );
+}

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -58,6 +58,10 @@ fetch.github = "catppuccin/micro"
 src.git = "https://github.com/catppuccin/nvim.git"
 fetch.github = "catppuccin/nvim"
 
+[palette]
+src.git = "https://github.com/catppuccin/palette"
+fetch.github = "catppuccin/palette"
+
 [polybar]
 src.git = "https://github.com/catppuccin/polybar.git"
 fetch.github = "catppuccin/polybar"

--- a/test.nix
+++ b/test.nix
@@ -28,6 +28,8 @@ in
 
     boot.loader.grub = ctpEnable;
 
+    console = ctpEnable;
+
     programs.dconf.enable = true; # required for gtk
 
     virtualisation = {


### PR DESCRIPTION
Add module for theming the tty. Resolves #12.

It uses the colors from [catppuccin/tty](https://github.com/catppuccin/tty), but I had to bring in [catppuccin/palette](https://github.com/catppuccin/palette) and parse `palette.json`. Also they appear to have gotten rid of the separate `palette-porcelain.json` file.