### PR TITLE
fix: apply lazygit theme

### DIFF
--- a/modules/home-manager/lazygit.nix
+++ b/modules/home-manager/lazygit.nix
@@ -19,6 +19,6 @@ in
 
   config = lib.mkIf enable {
 
-    programs.lazygit.settings = lib.ctp.fromYaml "${sources.lazygit}/themes/${themePath}";
+    programs.lazygit.settings = lib.ctp.fromYaml "${sources.lazygit}/themes-mergable/${themePath}";
   };
 }


### PR DESCRIPTION
use `themes-mergable` folder to apply lazygit theme as this has `gui` field

see https://github.com/catppuccin/lazygit/issues/13