### PR TITLE
feat(modules): expose palette in config.lib

### DIFF
--- a/modules/home-manager/globals.nix
+++ b/modules/home-manager/globals.nix
@@ -1,4 +1,17 @@
-{ lib, ... }: {
+{ config, lib, sources, ... }: {
+  config.lib.catppuccin =
+    let
+      cfg = config.catppuccin;
+      palettes = lib.importJSON "${sources.palette}/palette.json";
+      palette = palettes.${cfg.flavour};
+    in
+    {
+      inherit palettes;
+      palette = lib.attrsets.recursiveUpdate palette {
+        colors.accent = palette.colors.${cfg.accent};
+      };
+    };
+
   options.catppuccin = {
     flavour = lib.mkOption {
       type = lib.ctp.types.flavourOption;

--- a/modules/nixos/console.nix
+++ b/modules/nixos/console.nix
@@ -1,12 +1,11 @@
 { config
 , lib
-, sources
 , ...
 }:
 let
   cfg = config.console.catppuccin;
   enable = cfg.enable && config.console.enable;
-  palette = (lib.importJSON "${sources.palette}/palette.json").${cfg.flavour}.colors;
+  palette = config.lib.catppuccin.palettes.${cfg.flavour}.colors;
 in
 {
   options.console.catppuccin =

--- a/modules/nixos/globals.nix
+++ b/modules/nixos/globals.nix
@@ -1,4 +1,13 @@
-{ lib, ... }: {
+{ config, lib, sources, ... }: {
+  config.lib.catppuccin =
+    let
+      cfg = config.catppuccin;
+    in
+    rec {
+      palettes = lib.importJSON "${sources.palette}/palette.json";
+      palette = palettes.${cfg.flavour};
+    };
+
   options.catppuccin = {
     flavour = lib.mkOption {
       type = lib.ctp.types.flavourOption;


### PR DESCRIPTION
Exposes palettes to `config.lib` in both NixOS and Home Manager modules. Closes #96.

I essentially took `palette.json` from [catppuccin/palette](https://github.com/catppuccin/palette) and converted it into an attrset, `config.lib.catppuccin.palettes`. I also made it so the palette corresponding to the user's set flavor would be exposed by itself as `config.lib.catppuccin.palette`. In the home manager module, the latter also has an extra attribute that corresponds to the user's set accent color for convenience.